### PR TITLE
feat: only show install extension button if necessary [PART-1]

### DIFF
--- a/components/header/nav-expand.vue
+++ b/components/header/nav-expand.vue
@@ -122,6 +122,7 @@
         </section>
 
         <a
+          v-if="!extensionInstalled"
           href="https://chrome.google.com/webstore/detail/qiwallet/cjfeohjffkdehdblcolicjhhnbphcmna"
           target="_blank"
           :class="`bg-transparent md:bg-${theme}-assist-100`"
@@ -144,6 +145,7 @@
         </a>
         <!-- 打开 swap -->
         <locale-link
+          v-if="extensionInstalled"
           to="/swap/exchange"
           class="
             text-center
@@ -201,46 +203,56 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
-export default {
-  data() {
-    return {
-      showMenu: false,
-      navList: [
-        // { name: 'index', target: '/' },
-        // { name: 'transaction', target: '/swap/exchange' }
-        // { name: 'product', target: '/' },
-        { name: 'contact', target: '#contact' },
-        { name: 'faq', target: '#faq' },
-      ],
+import {
+  defineComponent,
+  ref,
+  computed,
+  useContext,
+  onMounted,
+  getCurrentInstance,
+} from '@nuxtjs/composition-api';
+export default defineComponent({
+  setup() {
+    const {
+      store: { state },
+    } = useContext();
+    const theme = computed(() => state.theme);
+    const extensionInstalled = computed(() => state.swap.extensionInstalled);
+    const showMenu = ref(false);
+    const toggleMenu = () => {
+      showMenu.value = !showMenu.value;
     };
-  },
-  computed: {
-    ...mapState(['theme']),
-  },
-  mounted() {
-    document.body.addEventListener(
-      'click',
-      () => {
-        this.showMenu = false;
-      },
-      false
-    );
-    this.$router.afterEach(() => {
-      this.showMenu = false;
-    });
-  },
-  methods: {
-    toggleMenu() {
-      this.showMenu = !this.showMenu;
-    },
-    hideOtherDropdown(name) {
+    function hideOtherDropdown(name) {
       for (const n in this.$refs) {
         if (name !== n && this.$refs[n].hide) {
           this.$refs[n].hide();
         }
       }
-    },
+    }
+    const navList = [
+      { name: 'contact', target: '#contact' },
+      { name: 'faq', target: '#faq' },
+    ];
+    onMounted(() => {
+      document.body.addEventListener(
+        'click',
+        () => {
+          showMenu.value = false;
+        },
+        false
+      );
+      getCurrentInstance()?.$router?.afterEach(() => {
+        showMenu.value = false;
+      });
+    });
+    return {
+      theme,
+      extensionInstalled,
+      showMenu,
+      toggleMenu,
+      hideOtherDropdown,
+      navList,
+    };
   },
-};
+});
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,7 +69,19 @@
             data-aos="fade-up"
             data-aos-delay="450"
           >
+            <a
+              v-if="!extensionInstalled"
+              href="https://chrome.google.com/webstore/detail/qiwallet/cjfeohjffkdehdblcolicjhhnbphcmna"
+              target="_blank"
+              :class="`bg-transparent md:bg-${theme}-assist-100`"
+              class="py-3 px-8 rounded mr-4 hover:opacity-75 transition-normal"
+            >
+              <span>
+                {{ $t('nav.install') }}
+              </span>
+            </a>
             <locale-link
+              v-if="extensionInstalled"
               to="/swap/exchange"
               :class="`bg-${theme}-assist-100`"
               class="py-3 px-8 rounded mr-4 hover:opacity-75 transition-normal"
@@ -92,7 +104,7 @@
               {{ $t('index.banner.doc') }}
             </a>
           </section>
-          <p class="mt-4 text-center md:px-6">
+          <p v-if="!extensionInstalled" class="mt-4 text-center md:px-6">
             {{ $t('index.banner.qiswap') }}
           </p>
         </div>
@@ -127,6 +139,7 @@ export default {
   data() {
     return {
       ...this.$t('index.plates'),
+      extensionInstalled: false,
     };
   },
   computed: {
@@ -138,6 +151,27 @@ export default {
     //   this.$nuxt.$loading.start()
     //   setTimeout(() => this.$nuxt.$loading.finish(), 100000)
     // })
+  },
+  beforeMount() {
+    window.postMessage(
+      { message: { type: 'VALIDATE_EXTENSION_INSTALLED' } },
+      '*'
+    );
+    window.addEventListener('message', this.setExtensionInstalled, false);
+  },
+  beforeDestroy() {
+    window.removeEventListener('message', this.setExtensionInstalled);
+  },
+  methods: {
+    setExtensionInstalled(event) {
+      const type = event?.data?.message?.type ?? '';
+      if (type === 'QRYPTO_INSTALLED_OR_UPDATED') {
+        window.location.reload();
+      } else if (type === 'EXTENSION_INSTALLED') {
+        this.extensionInstalled = true;
+        this.$store.commit('swap/setExtensionInstalled', true);
+      }
+    },
   },
 };
 </script>


### PR DESCRIPTION
NOTE: will have to be tested once the PR in QiWallet has been merged, or locally by changing the extensionId in swap.js to the  locally built qiwallet extension id.

If QiWallet isn't installed, the install buttons will be shown instead of "Launch swap" - and once installed, qiswap will get notified and reload, whereupon the "Launch swap" buttons will be shown instead.

However, users will ofc have to create an account & wallet before being able to swap, but it is still possible to launch the swap. But once an account is created it the balance will show up etc.

But we should maybe include some text about that in all translations.