### PR TITLE
chore: open navigation header docs in new tab

### DIFF
--- a/components/header/nav-expand.vue
+++ b/components/header/nav-expand.vue
@@ -168,6 +168,7 @@
             transition-normal
           "
           :class="`hover:text-${theme}-assist-200`"
+          target="_blank"
         >
           {{ $t(`nav.doc`) }}
         </a>


### PR DESCRIPTION
Change into opening the docs located in the navigation header in a new tab.