### PR TITLE
fix: require minimum 0.2 QTUM for swaps / liquidity

### DIFF
--- a/components/swap/amount-input.vue
+++ b/components/swap/amount-input.vue
@@ -21,7 +21,13 @@
       @blur="tokenAmount.inputing = false"
     />
     <div
-      v-if="tokenAmount.selected && showMax"
+      v-if="
+        tokenAmount.selected &&
+        showMax &&
+        (!tokenAmount.token.isQTUM ||
+          (tokenAmount.token.isQTUM &&
+            tokenAmount.token.balance.minus(0.2).gt(0)))
+      "
       class="
         py-1
         px-2
@@ -40,6 +46,7 @@
 </template>
 
 <script>
+import { BigNumber } from 'bignumber.js';
 export default {
   props: {
     tokenAmount: {
@@ -62,8 +69,11 @@ export default {
     setMax(e) {
       e.preventDefault();
       this.$refs.input.focus();
+      /* eslint-disable  */
       this.tokenAmount.inputing = true;
-      this.tokenAmount.input = this.tokenAmount.balance;
+      this.tokenAmount.input = this.tokenAmount.token.isQTUM
+        ? this.tokenAmount.balance.minus(new BigNumber(0.2))
+        : this.tokenAmount.balance;
     },
   },
 };

--- a/components/swap/process-buttons.vue
+++ b/components/swap/process-buttons.vue
@@ -1,7 +1,14 @@
 <template>
   <div class="flex">
     <button
-      v-if="shouldApprove[0] && !tokenAmount0.amountExceeded"
+      v-if="insufficientQtum"
+      class="process-button cursor-not-allowed"
+      :class="`bg-${theme}-inverse-300`"
+    >
+      {{ $t('swap.status.insufficientQtumBalance') }}
+    </button>
+    <button
+      v-else-if="shouldApprove[0] && !tokenAmount0.amountExceeded"
       class="process-button"
       :class="{
         [`bg-${theme}-assist-200 hover:bg-${theme}-assist-100`]:
@@ -17,7 +24,7 @@
       }}
     </button>
     <button
-      v-if="shouldApprove[1] && !tokenAmount1.amountExceeded && !isSwap"
+      v-else-if="shouldApprove[1] && !tokenAmount1.amountExceeded && !isSwap"
       class="process-button"
       :class="{
         [`bg-${theme}-assist-200 hover:bg-${theme}-assist-100`]:
@@ -33,7 +40,9 @@
       }}
     </button>
     <button
-      v-if="!tokenAmount0.selected || !tokenAmount1.selected"
+      v-else-if="
+        !insufficientQtum && (!tokenAmount0.selected || !tokenAmount1.selected)
+      "
       class="process-button cursor-not-allowed"
       :class="`bg-${theme}-inverse-300`"
     >
@@ -47,7 +56,10 @@
       {{ $t('swap.status.insufficient') }}
     </button>
     <button
-      v-else-if="tokenAmount0.amount.eq(0) || tokenAmount1.amount.eq(0)"
+      v-else-if="
+        !insufficientQtum &&
+        (tokenAmount0.amount.eq(0) || tokenAmount1.amount.eq(0))
+      "
       class="process-button cursor-not-allowed"
       :class="`bg-${theme}-inverse-300`"
     >
@@ -122,6 +134,9 @@ export default {
     },
     isSwap() {
       return this.type === TYPE_SWAP;
+    },
+    insufficientQtum() {
+      return this.$store.state.swap.account?.balance < 0.2;
     },
   },
 };

--- a/libs/swap/token-amount.js
+++ b/libs/swap/token-amount.js
@@ -25,6 +25,8 @@ export default class TokenAmount {
   }
 
   get amountExceeded() {
+    if (this.token.symbol === 'QTUM')
+      return this.amountSatoshi.gt(this.balanceSatoshi - 20000000);
     return this.amountSatoshi.gt(this.balanceSatoshi);
   }
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -168,6 +168,7 @@ export default {
       insufficient: 'Insufficient liquidity for this trade.',
       input: 'Input Amount',
       balance: 'Insufficient {tokenName} Balance',
+      insufficientQtumBalance: 'Insufficient QTUM Balance',
       swap: 'Swap',
       swaping: 'Swaping...',
       approve: 'Approve {tokenName}',

--- a/locales/es.js
+++ b/locales/es.js
@@ -172,6 +172,7 @@ export default {
       insufficient: 'Cantidad insuficiente para esta transaccion.',
       input: 'Ingrese cantidad',
       balance: 'Balance insuficiente de {tokenName}',
+      insufficientQtumBalance: 'Balance insuficiente de QTUM',
       swap: 'Swap',
       swaping: 'Swaping...',
       approve: 'Aprobar {tokenName}',

--- a/locales/zh.js
+++ b/locales/zh.js
@@ -171,6 +171,7 @@ export default {
       insufficient: '此交易对流动性不足',
       input: '输入金额',
       balance: '{tokenName} 余额不足',
+      insufficientQtumBalance: 'QTUM 余额不足',
       swap: '兑换',
       swaping: '兑换中...',
       approve: '授权 {tokenName}',


### PR DESCRIPTION
Using your maximum QTUM value for swaps or when sending liquidity to the pools does not work because of incorrect estimations.

As a quick-fix, we require users to save 0.2 QTUM for these transactions.

In order to test the PR, you will have to: 
- use a local built version of the QIWallet (the repo called qrypto) and change its manifest.json file to allow your local running qiswap.


```
  "externally_connectable": {
    "ids": [
      "*"
    ],
    "matches": [
      "*://*.qiswap.com/*",
      "http://localhost:3300/*"
    ]
  },

```

And then, you will have to  change the extensionId in this repo (in the swap.js file), to match the id of your built QiWallet which you can see if you go to this url in Chrome: chrome://extensions .

There will come more changes in all these three repos, but this will at least fix the problem for now.