### PR TITLE
fix: close approve modal for errors & when closing

### DIFF
--- a/libs/qrypto.js
+++ b/libs/qrypto.js
@@ -86,6 +86,7 @@ export default class Qrypto extends EventEmmiter {
     const { payload, type } = message || {};
     if (payload.error) {
       this.emit('error', payload.error);
+      this.emit('txCancelled');
       return;
     }
     // this.extensionInstalled = true


### PR DESCRIPTION
Close the approve transaction modal when having an error or when closing down the accept transaction window.